### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,15 @@ wget -P ~/bin/repo http://commondatastorage.googleapis.com/git-repo-downloads/re
 chmod a+x ~/bin/repo
 ```
 - Additional packages:
+### Ubuntu 18.04
 ```bash
-sudo apt-get install swig python-dev python3-dev libssl-dev flex bison device-tree-compiler mtools
+sudo apt-get install swig python-dev python3-dev libssl-dev flex bison device-tree-compiler mtools python3-pip git gettext
+sudo pip install Mako
+```
+
+### Ubuntu 20.04
+```bash
+sudo apt-get install swig python-dev-is-python2 python3-dev libssl-dev flex bison device-tree-compiler mtools python3-pip git gettext libncurses5
 sudo pip install Mako
 ```
   

--- a/README.md
+++ b/README.md
@@ -20,10 +20,14 @@ This version is based on [Android 10.0.0 Release 39](https://android.googlesourc
 
 ## You should install additional packages in order to build GloDroid under Ubuntu
 - [Google's required packages](https://source.android.com/setup/build/initializing).
-- Additional packages:
-  
+- Installing repo:
 ```bash
-sudo apt-get install swig repo python-dev python3-dev libssl-dev flex bison device-tree-compiler mtools
+wget -P ~/bin/repo http://commondatastorage.googleapis.com/git-repo-downloads/repo
+chmod a+x ~/bin/repo
+```
+- Additional packages:
+```bash
+sudo apt-get install swig python-dev python3-dev libssl-dev flex bison device-tree-compiler mtools
 sudo pip install Mako
 ```
   


### PR DESCRIPTION
Since the "repo" app has been removed from the default Ubuntu repos,
add steps to install the "repo" from the google repositories.

Add instruction for installing additional packages for Ubuntu 20.04.
Add missing packages for Ubuntu18.04 and Ubuntu20.04.