### PR TITLE
Add arm eabi cross compiler

### DIFF
--- a/glodroid.xml
+++ b/glodroid.xml
@@ -26,6 +26,8 @@
                                            remote="glodroid" name="linaro_gcc_prebuilts.git" revision="refs/tags/gcc-linaro-7.4.1-2019.02-x86_64_arm-linux-gnueabihf" />
   <project path="prebuilts/gcc/linux-x86/aarch64/gcc-linaro-aarch64-linux-gnu"
                                            remote="glodroid" name="linaro_gcc_prebuilts.git" revision="refs/tags/gcc-linaro-7.4.1-2019.02-x86_64_aarch64-linux-gnu" />
+  <project path="prebuilts/gcc/linux-x86/arm/gcc-linaro-arm-eabi"
+                                           remote="glodroid" name="linaro_gcc_prebuilts.git" revision="refs/tags/gcc-linaro-7.5.0-2019.12-x86_64_arm-eabi" />
 
   <project path="external/tinyhal"         remote="github" name="CirrusLogic/tinyhal.git"    revision="69d47887c13da461bf8400231a1c7f7290826037" />
   <project path="kernel/glodroid-modules/rtl8189es" remote="github" name="jwrdegoede/rtl8189ES_linux.git" revision="930d3d7cfe3b25c0cf8a57ca4b79f6aef5b6de4b" />


### PR DESCRIPTION
This cross compiler is needed for compiling atf.

Signed-off-by: Daniil Petrov <daniil.petrov@globallogic.com>