### PR TITLE
Add Dockerfile for building GloDroid on any Ubuntu distributions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+LABEL maintainer="Roman Marchenko <roman.marchenko@globallogic.com>"
+
+ENV PATH="/home/user/bin:${PATH}"
+RUN apt-get clean && apt-get update && apt-get upgrade -y
+
+# Install Google recommended packages ( https://source.android.com/setup/build/initializing#installing-required-packages-ubuntu-1804 )
+RUN apt-get install -y git-core gnupg flex bison build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z1-dev libgl1-mesa-dev libxml2-utils xsltproc unzip fontconfig
+
+# Install additional packages
+RUN apt-get install -y swig libssl-dev flex bison device-tree-compiler mtools git gettext libncurses5 libgmp-dev libmpc-dev cpio rsync dosfstools kmod gdisk wget
+
+# Install additional packages (for building mesa3d and other meson-based components)
+RUN apt-get install -y meson python3-pip pkg-config python3-dev
+RUN pip3 install mako
+
+# Install additional packages (required by repo utility)
+RUN apt-get install -y python-is-python3
+
+# Create new user
+RUN useradd -m user
+USER user
+
+# Install repo
+RUN wget -P ~/bin http://commondatastorage.googleapis.com/git-repo-downloads/repo
+RUN chmod a+x ~/bin/repo
+
+# Prepare workdir
+RUN mkdir ~/aosp
+WORKDIR /home/user/aosp


### PR DESCRIPTION
**Step 1**: Install Docker Engine on your host machine
The instruction for Docker installation is on [the official site](https://docs.docker.com/engine/install/).

**Step 2**: Build Docker image
`$ docker build -t glodroid https://github.com/GloDroid/glodroid_manifest.git#master`

**Step 3:** Map the location of GloDroid source code that will be saved on your host machine in **docker run** command
`$ docker run -it -v <path_to_local_glodroid>:/home/user/aosp:z --user "$(id -u):$(id -g)" glodroid`

Once you run your Docker container, you can fetch and build AOSP with the usual commands.

**Step 4:**  Set the global git options in the container 
`$ git config --global user.name "Your Name"`
`$ git config --global user.email "you@example.com"`

**Step 5:** [Fetch Android sources](https://github.com/GloDroid/glodroid_manifest#fetching-android-sources)
`$ repo init -u https://github.com/glodroid/glodroid_manifest`
`$ repo sync -cq`

**Step 6:** [Build GloDroid](https://github.com/GloDroid/glodroid_manifest#building-glodroid)
`$ source ./build/envsetup.sh`
`$ lunch pinephone-userdebug`
`$ make -j3`
`$ make images`


Signed-off-by: Roman Marchenko <roman.marchenko@globallogic.com>